### PR TITLE
UIViewDragDropDelegate optional methods

### DIFF
--- a/Classes/UIView+DragDrop.h
+++ b/Classes/UIView+DragDrop.h
@@ -43,10 +43,9 @@ typedef NS_ENUM( NSInteger, UIViewDragDropMode) {
  */
 @protocol UIViewDragDropDelegate <NSObject>
 
+- (void) view:(UIView *)view wasDroppedOnDropView:(UIView *)drop;
 
 @optional
-
-- (void) view:(UIView *)view wasDroppedOnDropView:(UIView *)drop;
 
 - (BOOL) viewShouldReturnToStartingPosition:(UIView*)view;
 

--- a/Classes/UIView+DragDrop.m
+++ b/Classes/UIView+DragDrop.m
@@ -120,13 +120,17 @@ static char _delegate, _dropViews, _startPos, _isHovering, _mode;
             if (CGRectIntersectsRect(self.frame, v.frame)) {
                 //notify delegate if we're on a drop view
                 if (isHovering == NO) {
-                    [delegate view:self didHoverOverDropView:v];
+                    if ([delegate respondsToSelector:@selector(view:didHoverOverDropView:)]) {
+                        [delegate view:self didHoverOverDropView:v];
+                    }
                     isHovering = YES;
                 }
             } else {
                 if (isHovering == YES) {
                     isHovering = NO;
-                    [delegate view:self didUnhoverOverDropView:v];
+                    if ([delegate respondsToSelector:@selector(view:didUnhoverOverDropView:)]) {
+                        [delegate view:self didUnhoverOverDropView:v];
+                    }
                 }
             }
         }


### PR DESCRIPTION
In protocol declaration of UIViewDragDropDelegate all methods are marked as optional, but these three has to be implemented (are called without checking if implemented):

(void) view:(UIView *)view wasDroppedOnDropView:(UIView *)drop;

(void) draggingDidBeginForView:(UIView*)view;

(void) draggingDidEndWithoutDropForView:(UIView*)view;
