### PR TITLE
Additional Delegate call, and common superview hit testing

### DIFF
--- a/Classes/UIView+DragDrop.h
+++ b/Classes/UIView+DragDrop.h
@@ -48,6 +48,8 @@ typedef NS_ENUM( NSInteger, UIViewDragDropMode) {
 @optional
 
 - (BOOL) viewShouldReturnToStartingPosition:(UIView*)view;
+- (void) viewDidReturnToStartingPosition:(UIView *)view;
+
 
 - (void) draggingDidBeginForView:(UIView*)view;
 - (void) draggingDidEndWithoutDropForView:(UIView*)view;

--- a/Classes/UIView+DragDrop.m
+++ b/Classes/UIView+DragDrop.m
@@ -168,7 +168,12 @@ static char _delegate, _dropViews, _startPos, _isHovering, _mode;
             CGPoint c = CGPointMake(x, y);
             
             [UIView animateWithDuration:RESET_ANIMATION_DURATION
-                             animations:^{ self.center = c; }];
+                 animations:^{ self.center = c; } completion:^(BOOL finished) {
+                     if ([delegate respondsToSelector:@selector(viewDidReturnToStartingPosition:)])
+                     {
+                         [delegate viewDidReturnToStartingPosition:self];
+                     }
+                 }];
         }
     }
 }


### PR DESCRIPTION
There are 2 changes here:
1.  Add a delegate call for when the view did return to the starting position
2.  More importantly - if views were not direct siblings of each other, the hit testing for hover and drop were not correct.  Added in a check to use the nearest parent view of both views (drop views, and the dragged view) in order to do hover and drop testing.
